### PR TITLE
convert doc comment to regular comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,9 +349,9 @@ named!(pub nulls_where <NullsWhere>,
     )
 );
 
-/// hard to distinguest `column.direction` from `table.column`
-/// i.e: `person.age` and `age.desc`
-/// use strict `column_only` instead, which doesn't include `.`
+// hard to distinguest `column.direction` from `table.column`
+// i.e: `person.age` and `age.desc`
+// use strict `column_only` instead, which doesn't include `.`
 named!(pub order <Order>,
     do_parse!(
         col: column_only >>


### PR DESCRIPTION
[rust-lang/rust#57882](https://github.com/rust-lang/rust/pull/57882) is modifying the `unused_doc_comments` lint to fire on mistakenly documented macro expansions. A crater run detected that this crate will break due to this change, likely because of the use of `deny(unused_doc_comments)` or `deny(warnings)`.

While this kind of breakage is allowed under Rust's stability guarantees, I am opening PRs to affected crates to reduce the impact.

This PR protects your crate from future breakage by converting the offending doc comment to a regular comment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ivanceras/inquerest/3)
<!-- Reviewable:end -->
